### PR TITLE
fix: Encode regex in UTF-8 before matching

### DIFF
--- a/update_slots.rb
+++ b/update_slots.rb
@@ -58,6 +58,7 @@ dirs.each do |dir|
           else
             slot_regex = /\s*#{component_name}\.#{slot_name}(\s*(\(\s*.*?\))?\s*(do)?|\s*do|\s*do\s*)/ms
           end
+          slot_regex = Regexp.new(slot_regex.source.force_encoding("UTF-8"))
           lines = data.split("\n")
           
           # For each occurrence of the slot, replace it with "with_" prefix


### PR DESCRIPTION
While using the script, I encountered a encoding error that was resolved by explicitly converting the regex to UTF-8. Please discard if unnecessary.